### PR TITLE
Update initClipboardJS to be handled async

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -56,7 +56,7 @@ async function initClipboardJS(options) {
     throw minified.error;
   }
   return `<script>${minified.code}</script>
-<script async src="https://cdn.jsdelivr.net/npm/clipboard@${options.clipboardJSVersion}/dist/clipboard.js"></script>`;
+<script async src="https://cdn.jsdelivr.net/npm/clipboard@${options.clipboardJSVersion}/dist/clipboard.min.js"></script>`;
 }
 
 module.exports = {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,7 +65,7 @@ module.exports = {
       ...defaultPluginOptions,
       ...pluginOptions,
     };
-    eleventyConfig.addNunjucksAsyncShortcode('initClipboardJS', async () => await initClipboardJS(pluginFallbackOptions));
+    eleventyConfig.addAsyncShortcode('initClipboardJS', async () => initClipboardJS(pluginFallbackOptions));
   },
   markdownItCopyButton(md, rendererOptions) {
     const rendererFallbackOptions = {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -46,8 +46,8 @@ function renderCode(origRule, rendererOptions) {
   };
 }
 
-function initClipboardJS(options) {
-  const originSource = fs.readFileSync(path.join(__dirname, '/init-clipboard.js')).toString();
+async function initClipboardJS(options) {
+  const originSource = (await fs.promises.readFile(path.join(__dirname, '/init-clipboard.js'))).toString();
   const script = originSource.replace('new ClipboardJS(\'\')', `new ClipboardJS('.${options.buttonClass}')`)
     .replace('Copied!', options.successMessage)
     .replace('Failed...', options.failureMessage);
@@ -65,7 +65,7 @@ module.exports = {
       ...defaultPluginOptions,
       ...pluginOptions,
     };
-    eleventyConfig.addShortcode('initClipboardJS', () => initClipboardJS(pluginFallbackOptions));
+    eleventyConfig.addNunjucksAsyncShortcode('initClipboardJS', async () => await initClipboardJS(pluginFallbackOptions));
   },
   markdownItCopyButton(md, rendererOptions) {
     const rendererFallbackOptions = {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,7 +3,7 @@ const path = require('path');
 const UglifyJS = require('uglify-js');
 
 const defaultPluginOptions = {
-  clipboardJSVersion: '2.0.8',
+  clipboardJSVersion: '2.0.11',
   buttonClass: 'code-copy',
   successMessage: 'Copied!',
   failureMessage: 'Failed...',


### PR DESCRIPTION
Currently the initClipboardJS shortcode is handled synchronously and blocks the 11ty render, which leads to output in the build logs:

> [11ty] Benchmark    206ms  30%   110× (Configuration) "initClipboardJS" Nunjucks Shortcode

This PR updates the shortcode to he handled async and non-blocking.

Additionally it:
 - Upgrades to 2.0.11 for a couple of bug fixes - https://github.com/zenorocha/clipboard.js/releases
 - Uses the minified version of the script, to save a couple of kB