### PR TITLE
Add matching id to code/button parent

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,7 @@ function renderCode(origRule, rendererOptions) {
       return origRendered;
     }
     return `
-<div style="position: relative">
+<div style="position: relative" ${self.renderAttrs(tokens[idx])}>
   ${origRendered.replace(/<code/, `<code id="code-${idx}"`)}
   <button class="${rendererOptions.buttonClass} ${rendererOptions.additionalButtonClass}"
     data-clipboard-target="#code-${idx}"

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,7 @@ function renderCode(origRule, rendererOptions) {
       return origRendered;
     }
     return `
-<div style="position: relative">
+<div style="position: relative" id="code-container-${idx}">
   ${origRendered.replace(/<code/, `<code id="code-${idx}"`)}
   <button class="${rendererOptions.buttonClass} ${rendererOptions.additionalButtonClass}"
     data-clipboard-target="#code-${idx}"


### PR DESCRIPTION
We use event trackers in our documentation to check progress of users through our installation.

The click events are sometimes on the parent div, not the specific "copy" button. It'd be really helpful for the parent to also contain a reference to the same "idx" so that we can clearly track the events