### PR TITLE
Persist attributes defined on code blocks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,7 @@ function renderCode(origRule, rendererOptions) {
       return origRendered;
     }
     return `
-<div style="position: relative">
+<div style="position: relative" ${self.renderAttrs(tokens[idx])}>
   ${origRendered.replace(/<code/, `<code id="code-${idx}"`)}
   <button class="${rendererOptions.buttonClass} ${rendererOptions.additionalButtonClass}"
     data-clipboard-target="#code-${idx}"

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,7 @@ function renderCode(origRule, rendererOptions) {
       return origRendered;
     }
     return `
-<div style="position: relative">
+<div style="position: relative" id="code-container-${idx}">
   ${origRendered.replace(/<code/, `<code id="code-${idx}"`)}
   <button class="${rendererOptions.buttonClass} ${rendererOptions.additionalButtonClass}"
     data-clipboard-target="#code-${idx}"


### PR DESCRIPTION
When using https://www.npmjs.com/package/markdown-it-attrs we are able to define attributes to be appended to elements in our markdown, e.g:

```md
paragraph {data-toggle=modal}
```

would render:

```html
<p data-toggle="modal">paragraph</p>
```

It does also support injection of attributes on the fenced code blocks, but this Eleventy Plugin does not consider the `attrs` defined. This PR adds that in such that the introduced parent `<div>` takes ownership of the attributes.

For example, if, in my markdown, I include:

```` 
```python
nums = [x for x in range(10)]
```

```python {data=hello}
nums = [x for x in range(10)]
```
````

Then the following elements are rendered to my DOM:

<img width="411" alt="Screenshot 2024-09-27 at 14 15 12" src="https://github.com/user-attachments/assets/6ba21e9e-5a50-493f-a56d-b5d24fe950bc">


